### PR TITLE
chore: update infection to 0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofphp/php-cs-fixer": "^2.13",
         "google/cloud-pubsub": "^1.21",
         "google/cloud-tasks": "^1.5",
-        "infection/infection": "^0.10",
+        "infection/infection": "^0.13",
         "league/fractal": "^0.19",
         "michaelmoussa/php-coverage-checker": "^1.1",
         "mockery/mockery": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "691139ede91d7326e39669a7e74cd449",
+    "content-hash": "6d3f3a76d583765aa6ad9321a672f579",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1780,32 +1780,35 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.10.6",
+            "version": "0.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "ccffd492fd235d66bc0407880bc121a28026d3f5"
+                "reference": "09b4d371d203f7f22dcf1741a3f6c657404fb61e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/ccffd492fd235d66bc0407880bc121a28026d3f5",
-                "reference": "ccffd492fd235d66bc0407880bc121a28026d3f5",
+                "url": "https://api.github.com/repos/infection/infection/zipball/09b4d371d203f7f22dcf1741a3f6c657404fb61e",
+                "reference": "09b4d371d203f7f22dcf1741a3f6c657404fb61e",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.1",
+                "composer/xdebug-handler": "^1.3",
                 "ext-dom": "*",
-                "nikic/php-parser": "^4.0",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "justinrainbow/json-schema": "^5.2",
+                "nikic/php-parser": "^4.2.1",
                 "ocramius/package-versions": "^1.2",
                 "padraic/phar-updater": "^1.0.4",
-                "php": "^7.1",
+                "php": "^7.1.3",
                 "pimple/pimple": "^3.2",
                 "sebastian/diff": "^1.4 || ^2.0 || ^3.0",
-                "symfony/console": "^3.2 || ^4.0",
-                "symfony/filesystem": "^3.2 || ^4.0",
-                "symfony/finder": "^3.2 || ^4.0",
-                "symfony/process": "^3.2 || ^4.0",
-                "symfony/yaml": "^3.2 || ^4.0",
+                "symfony/console": "^3.4 || ^4.0",
+                "symfony/filesystem": "^3.4 || ^4.0",
+                "symfony/finder": "^3.4 || ^4.0",
+                "symfony/process": "^3.4 || ^4.0",
+                "symfony/yaml": "^3.4 || ^4.0",
                 "webmozart/assert": "^1.3"
             },
             "conflict": {
@@ -1813,8 +1816,8 @@
                 "symfony/process": "3.4.2"
             },
             "require-dev": {
-                "mockery/mockery": "^1.1",
-                "phpunit/phpunit": "^6"
+                "helmich/phpunit-json-assert": "^2.1 || ^3.0",
+                "phpunit/phpunit": "^7.5"
             },
             "bin": [
                 "bin/infection"
@@ -1836,6 +1839,10 @@
                     "homepage": "https://twitter.com/maks_rafalko"
                 },
                 {
+                    "name": "Oleg Zhulnev",
+                    "homepage": "https://github.com/sidz"
+                },
+                {
                     "name": "Gert de Pagter",
                     "homepage": "https://github.com/BackEndTea"
                 },
@@ -1843,10 +1850,6 @@
                     "name": "Théo FIDRY",
                     "email": "theo.fidry@gmail.com",
                     "homepage": "https://twitter.com/tfidry"
-                },
-                {
-                    "name": "Oleg Zhulnev",
-                    "homepage": "https://github.com/sidz"
                 },
                 {
                     "name": "Alexey Kopytko",
@@ -1863,7 +1866,7 @@
                 "testing",
                 "unit testing"
             ],
-            "time": "2018-10-30T19:14:11+00:00"
+            "time": "2019-08-29T19:22:44+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -13,5 +13,9 @@
         "badge": {
             "branch": "master"
         }
+    },
+    "mutators": {
+        "@default": true,
+        "@function_signature": false
     }
 }


### PR DESCRIPTION
Continuation of PR #22.

List of new mutators to be handled:
 - UnwrapArrayCombine mutator
 - UnwrapArrayFlip mutator
 - UnwrapArrayReverse mutator
 - UnwrapStrRepeat mutator
 - UnwrapArrayReplace mutator
 - UnwrapStrToLower mutator
 - UnwrapArrayReduce mutator
 - UnwrapArrayReplaceRecursive mutator
 - UnwrapArrayDiff mutator
 - UnwrapArrayIntersect mutator
 - UnwrapArrayMerge mutator
 - UnwrapArrayChunk mutator
 - UnwrapArrayUnique mutator
 - UnwrapArrayKeys mutator
 - UnwrapArrayValues mutator
 - UnwrapStrToUpper mutator
 - UnwrapArrayUdiffAssoc mutator
 - UnwrapArraySplice mutator
 - UnwrapArraySlice mutator
 - UnwrapArrayMergeRecursive mutator
 - UnwrapArrayIntersectUkey mutator
 - UnwrapArrayIntersectUassoc mutator
 - UnwrapArrayColumn mutator
 - UnwrapArrayIntersectKey mutator
 - UnwrapArrayDiffUkey mutator
 - Family bc*-functions mutators (bcmath support) #658
 - Family mb_*-functions mutators #654
 - Add a new unwrap mutator: ucwords #644
 - New @unwrap mutator: lcfirst() #642
 - Provide compact output for CI environments #613
 - add unwrap array_pad mutator #680
 - add unwrap array_intersect_assoc mutator #679
 - #597 Array item removal mutator #649
 - Enhancement: Implement UnwrapTrim mutator #638
 - Enhancement: Implement UnwrapArrayUintersect mutator #637
 - Enhancement: Implement UnwrapArrayUintersectUassoc mutator #633
 - Enhancement: Implement UnwrapArrayUintersectAssoc mutator #628
 - Enhancement: Implement UnwrapArrayUdiff mutator #624
 - Mutator: AssignCoalesce. Upgrade PHPParser to 4.2.1 #641
 - Mutator: UnwrapUcFirst (unwrap the first argument of ucfirst() function) #635
 - [Mutator] Mutate mb_str_split to str_split #787
 - [Mutator] Spread operator in Array Expression - leave only the first element #784
 - [Mutator] Leave only one element in the non empty returned array #735
