### PR TITLE
Support for CloudTask OIDC and OAuth Tokens + helper methods to jobs

### DIFF
--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -31,4 +31,16 @@ interface Job
     public function getTypeIdentifier() : string;
 
     public function getJobId() : Uuid;
+
+    public function setContext(array $data) : void;
+
+    public function addContext(string $key, $value) : void;
+
+    public function getContextEntry(string $key);
+
+    public function setOutput(array $data) : void;
+
+    public function addOutput(string $key, $value) : void;
+
+    public function getOutput() : array;
 }

--- a/src/Job/Jobs/DefaultJob.php
+++ b/src/Job/Jobs/DefaultJob.php
@@ -47,6 +47,12 @@ abstract class DefaultJob implements Job
     /** @var WorkerFactoryInterface */
     protected $workerFactory;
 
+    /** @var array */
+    protected $context = [];
+
+    /** @var array */
+    protected $output = [];
+
     /** @var bool */
     protected $finished = false;
 
@@ -205,6 +211,36 @@ abstract class DefaultJob implements Job
     protected function getWorkersConfig() : array
     {
         return $this->getConfigParameters()['workers'] ?? [];
+    }
+
+    public function setContext(array $data) : void
+    {
+        $this->context = $data;
+    }
+
+    public function addContext(string $key, $value) : void
+    {
+        $this->context[$key] = $value;
+    }
+
+    public function getContextEntry(string $key)
+    {
+        return $this->context[$key] ?? null;
+    }
+
+    public function addOutput(string $key, $value) : void
+    {
+        $this->output[$key] = $value;
+    }
+
+    public function setOutput(array $data) : void
+    {
+        $this->output = $data;
+    }
+
+    public function getOutput() : array
+    {
+        return $this->output;
     }
 
     public function getConfig() : array

--- a/src/Job/Output/Transformer/JobDetails.php
+++ b/src/Job/Output/Transformer/JobDetails.php
@@ -15,6 +15,7 @@ class JobDetails extends TransformerAbstract
             'finished' => $job->isFinished(),
             'successful' => $job->isSuccessful(),
             'duration' => $job->getDuration(),
+            'output' => $job->getOutput(),
             'errors' => $job->getErrors(),
         ];
     }

--- a/src/Job/Workers/Factory/DefaultWorkerFactory.php
+++ b/src/Job/Workers/Factory/DefaultWorkerFactory.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace LinioPay\Idle\Job\Workers\Factory;
 
+use Laminas\Stdlib\ArrayUtils;
 use LinioPay\Idle\Job\Exception\ConfigurationException;
 use LinioPay\Idle\Job\Worker as WorkerInterface;
 use LinioPay\Idle\Job\WorkerFactory as WorkerFactoryInterface;
 use Psr\Container\ContainerInterface;
-use Zend\Stdlib\ArrayUtils;
 
 abstract class DefaultWorkerFactory implements WorkerFactoryInterface
 {

--- a/src/Message/Messages/Factory/DefaultServiceFactory.php
+++ b/src/Message/Messages/Factory/DefaultServiceFactory.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LinioPay\Idle\Message\Messages\Factory;
 
+use Laminas\Stdlib\ArrayUtils;
 use LinioPay\Idle\Message\Exception\ConfigurationException;
 use LinioPay\Idle\Message\Message;
 use LinioPay\Idle\Message\Service;
 use LinioPay\Idle\Message\ServiceFactory as ServiceFactoryInterface;
 use Psr\Container\ContainerInterface;
-use Zend\Stdlib\ArrayUtils;
 
 abstract class DefaultServiceFactory implements ServiceFactoryInterface
 {

--- a/tests/Job/Jobs/SimpleJobTest.php
+++ b/tests/Job/Jobs/SimpleJobTest.php
@@ -173,6 +173,32 @@ class SimpleJobTest extends TestCase
         $this->assertSame('simple', $job->getTypeIdentifier());
     }
 
+    public function testCanGetAndSetWorkerContext()
+    {
+        $job = new SimpleJob($this->config, $this->workerFactory);
+
+        $job->setContext(['foo' => 'bar']);
+        $this->assertSame('bar', $job->getContextEntry('foo'));
+
+        $job->addContext('baz', 'foo');
+        $this->assertSame('foo', $job->getContextEntry('baz'));
+    }
+
+    public function testCanGetAndSetOutput()
+    {
+        $job = new SimpleJob($this->config, $this->workerFactory);
+
+        $job->setOutput(['foo' => 'bar']);
+        $job->addOutput('baz', 'foo');
+
+        $output = $job->getOutput();
+
+        $this->assertIsArray($output);
+
+        $this->assertArrayHasKey('foo', $output);
+        $this->assertArrayHasKey('baz', $output);
+    }
+
     public function testItThrowsConfigurationExceptionWhenJobConfigurationIsInvalid()
     {
         $failConfig = [

--- a/tests/Job/Output/Transformer/JobDetailsTest.php
+++ b/tests/Job/Output/Transformer/JobDetailsTest.php
@@ -17,6 +17,7 @@ class JobDetailsTest extends TestCase
             'finished' => true,
             'successful' => false,
             'duration' => 0.0,
+            'output' => [],
             'errors' => ['error'],
         ], (new JobDetails())->transform($job));
     }

--- a/tests/Message/Messages/Queue/Service/SQS/ServiceTest.php
+++ b/tests/Message/Messages/Queue/Service/SQS/ServiceTest.php
@@ -6,6 +6,7 @@ namespace LinioPay\Idle\Message\Messages\Queue\Service\SQS;
 
 use Aws\Result;
 use Aws\Sqs\SqsClient;
+use Laminas\Stdlib\ArrayUtils;
 use LinioPay\Idle\Message\Exception\FailedReceivingMessageException;
 use LinioPay\Idle\Message\Exception\InvalidMessageParameterException;
 use LinioPay\Idle\Message\Messages\Queue\Message as QueueMessageInterface;
@@ -13,7 +14,6 @@ use LinioPay\Idle\Message\Messages\Queue\Message\Message;
 use LinioPay\Idle\TestCase;
 use Mockery as m;
 use Monolog\Handler\TestHandler;
-use Zend\Stdlib\ArrayUtils;
 
 class ServiceTest extends TestCase
 {


### PR DESCRIPTION
- Add support for OIDC and OAuth Tokens which can be passed to the Message as attributes.
- Add context support on jobs.  This allows workers to share context data and allows information to be shared between workers.
- Add output support on jobs.  This allows the job to output some basic information about the job.  