### PR TITLE
[CP-1084] styles: align and order class lint

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,7 +14,19 @@ return $config->setRules([
         'return_type_declaration' => ['space_before' => 'one'],
         'no_unreachable_default_argument_value' => false,
         'yoda_style' => false,
-        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'increment_style' => ['style' => 'pre'],
+        'phpdoc_align' => ['align' => 'left'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'ordered_class_elements' =>  [
+            'order' =>
+                [
+                    'use_trait', 'constant_public', 'constant_protected', 'constant_private', 'property_public',
+                    'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit',
+                    'method_public', 'method_public_abstract', 'method_protected_abstract', 'method_protected',
+                    'method_private', 'method_public_abstract_static', 'method_protected_abstract_static',
+                    'method_public_static', 'method_protected_static',
+                ],
+            'sort_algorithm' => 'alpha'
+        ],
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,9 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": false
+        }
     }
 }

--- a/src/Config/Exception/ConfigurationException.php
+++ b/src/Config/Exception/ConfigurationException.php
@@ -7,9 +7,9 @@ namespace LinioPay\Idle\Config\Exception;
 class ConfigurationException extends \Exception
 {
     const ENTITY_JOB = 'Job';
-    const ENTITY_WORKER = 'Worker';
     const ENTITY_MESSAGE = 'Message';
     const ENTITY_SERVICE = 'Service';
+    const ENTITY_WORKER = 'Worker';
 
     const MESSAGE = '%s %s is missing a proper %s configuration.';
 

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -9,19 +9,19 @@ use Ramsey\Uuid\UuidInterface;
 interface Job
 {
     /**
-     * Begin executing the job.
+     * Adds an entry to the context.  Useful to share data between workers.
      */
-    public function process() : void;
+    public function addContext(string $key, $value) : void;
 
     /**
-     * Retrieve an array of error messages which occurred while processing the job.
+     * Adds an entry to the output data.  Useful to specify data which the job will output.
      */
-    public function getErrors() : array;
+    public function addOutput(string $key, $value) : void;
 
     /**
-     * Whether the job completed successfully or not.
+     * Retrieve the value of specific key in the context. Useful to share data between workers.
      */
-    public function isSuccessful() : bool;
+    public function getContextEntry(string $key);
 
     /**
      * Overall duration of job execution.
@@ -29,24 +29,24 @@ interface Job
     public function getDuration() : float;
 
     /**
+     * Retrieve an array of error messages which occurred while processing the job.
+     */
+    public function getErrors() : array;
+
+    /**
+     * Retrieve the id for the job.
+     */
+    public function getJobId() : UuidInterface;
+
+    /**
+     * Retrieves the output data.
+     */
+    public function getOutput() : array;
+
+    /**
      * Retrieve all job parameters.
      */
     public function getParameters() : array;
-
-    /**
-     * Set job parameters.
-     */
-    public function setParameters(array $parameters = []) : void;
-
-    /**
-     * Verifies the parameters for the job are valid.
-     */
-    public function validateParameters() : void;
-
-    /**
-     * Whether the job finished executing or not.
-     */
-    public function isFinished() : bool;
 
     /**
      * Retrieve data which we may wish to persist.
@@ -59,9 +59,19 @@ interface Job
     public function getTypeIdentifier() : string;
 
     /**
-     * Retrieve the id for the job.
+     * Whether the job finished executing or not.
      */
-    public function getJobId() : UuidInterface;
+    public function isFinished() : bool;
+
+    /**
+     * Whether the job completed successfully or not.
+     */
+    public function isSuccessful() : bool;
+
+    /**
+     * Begin executing the job.
+     */
+    public function process() : void;
 
     /**
      * Sets and replaces the entire context.  Useful to share data between workers.
@@ -69,27 +79,17 @@ interface Job
     public function setContext(array $data) : void;
 
     /**
-     * Adds an entry to the context.  Useful to share data between workers.
-     */
-    public function addContext(string $key, $value) : void;
-
-    /**
-     * Retrieve the value of specific key in the context. Useful to share data between workers.
-     */
-    public function getContextEntry(string $key);
-
-    /**
      * Sets and replaces the entire output data.  Useful to specify data which the job will output.
      */
     public function setOutput(array $data) : void;
 
     /**
-     * Adds an entry to the output data.  Useful to specify data which the job will output.
+     * Set job parameters.
      */
-    public function addOutput(string $key, $value) : void;
+    public function setParameters(array $parameters = []) : void;
 
     /**
-     * Retrieves the output data.
+     * Verifies the parameters for the job are valid.
      */
-    public function getOutput() : array;
+    public function validateParameters() : void;
 }

--- a/src/Job/Jobs/Factory/DefaultJobFactory.php
+++ b/src/Job/Jobs/Factory/DefaultJobFactory.php
@@ -23,10 +23,10 @@ abstract class DefaultJobFactory implements JobFactoryInterface
         $this->loadIdleConfig();
     }
 
+    abstract public function createJob(string $jobIdentifier, array $parameters) : Job;
+
     protected function loadIdleConfig() : void
     {
         $this->idleConfig = $this->container->get(IdleConfig::class);
     }
-
-    abstract public function createJob(string $jobIdentifier, array $parameters) : Job;
 }

--- a/src/Job/Jobs/FailedJob.php
+++ b/src/Job/Jobs/FailedJob.php
@@ -16,13 +16,13 @@ class FailedJob extends DefaultJob
         $this->successful = false;
     }
 
-    public function process() : void
-    {
-        // Nothing to do
-    }
-
     public function getErrors() : array
     {
         return $this->errors;
+    }
+
+    public function process() : void
+    {
+        // Nothing to do
     }
 }

--- a/src/Job/Jobs/MessageJob.php
+++ b/src/Job/Jobs/MessageJob.php
@@ -46,13 +46,12 @@ class MessageJob extends DefaultJob
         }
     }
 
-    protected function getMessageJobSourceConfig() : array
+    protected function buildWorker(string $workerIdentifier, array $workerParameters) : WorkerInterface
     {
-        $messageJobParameters = $this->idleConfig->getJobParametersConfig(self::IDENTIFIER);
-        $messageTypeIdentifier = $this->message->getIdleIdentifier();
-        $messageSourceIdentifier = $this->message->getSourceName();
-
-        return $messageJobParameters[$messageTypeIdentifier][$messageSourceIdentifier] ?? [];
+        return $this->workerFactory->createWorker($workerIdentifier, array_merge(
+            $workerParameters,
+            ['job' => $this, 'message' => $this->message]
+        ));
     }
 
     /**
@@ -65,11 +64,12 @@ class MessageJob extends DefaultJob
         return $config['parameters']['workers'] ?? [];
     }
 
-    protected function buildWorker(string $workerIdentifier, array $workerParameters) : WorkerInterface
+    protected function getMessageJobSourceConfig() : array
     {
-        return $this->workerFactory->createWorker($workerIdentifier, array_merge(
-            $workerParameters,
-            ['job' => $this, 'message' => $this->message]
-        ));
+        $messageJobParameters = $this->idleConfig->getJobParametersConfig(self::IDENTIFIER);
+        $messageTypeIdentifier = $this->message->getIdleIdentifier();
+        $messageSourceIdentifier = $this->message->getSourceName();
+
+        return $messageJobParameters[$messageTypeIdentifier][$messageSourceIdentifier] ?? [];
     }
 }

--- a/src/Job/Jobs/SimpleJob.php
+++ b/src/Job/Jobs/SimpleJob.php
@@ -39,17 +39,17 @@ class SimpleJob extends DefaultJob
         }
     }
 
-    protected function getSimpleJobConfig() : array
-    {
-        $jobConfigParameters = $this->idleConfig->getJobParametersConfig(self::IDENTIFIER);
-
-        return $jobConfigParameters['supported'][$this->simpleIdentifier] ?? [];
-    }
-
     protected function getJobWorkersConfig() : array
     {
         $config = $this->getSimpleJobConfig();
 
         return $config['parameters']['workers'] ?? [];
+    }
+
+    protected function getSimpleJobConfig() : array
+    {
+        $jobConfigParameters = $this->idleConfig->getJobParametersConfig(self::IDENTIFIER);
+
+        return $jobConfigParameters['supported'][$this->simpleIdentifier] ?? [];
     }
 }

--- a/src/Job/Worker.php
+++ b/src/Job/Worker.php
@@ -7,16 +7,6 @@ namespace LinioPay\Idle\Job;
 interface Worker
 {
     /**
-     * Perform the worker's work.
-     */
-    public function work() : bool;
-
-    /**
-     * Define the parameters for the worker.
-     */
-    public function setParameters(array $parameters) : void;
-
-    /**
      * Retrieve any errors caused by the execution of the worker.
      */
     public function getErrors() : array;
@@ -27,7 +17,17 @@ interface Worker
     public function getParameters() : array;
 
     /**
+     * Define the parameters for the worker.
+     */
+    public function setParameters(array $parameters) : void;
+
+    /**
      * Verifies the worker's parameters are valid.
      */
     public function validateParameters() : void;
+
+    /**
+     * Perform the worker's work.
+     */
+    public function work() : bool;
 }

--- a/src/Job/Workers/DefaultWorker.php
+++ b/src/Job/Workers/DefaultWorker.php
@@ -12,14 +12,24 @@ abstract class DefaultWorker implements Worker
     public static $skipFactory = false;
 
     /** @var array */
-    protected $parameters = [];
+    protected $errors = [];
 
     /** @var array */
-    protected $errors = [];
+    protected $parameters = [];
+
+    public function getErrors() : array
+    {
+        return $this->errors;
+    }
 
     public function getParameters() : array
     {
         return $this->parameters;
+    }
+
+    public function getTrackerData() : array
+    {
+        return [];
     }
 
     public function setParameters(array $parameters) : void
@@ -27,23 +37,13 @@ abstract class DefaultWorker implements Worker
         $this->parameters = $parameters;
     }
 
-    public function getErrors() : array
-    {
-        return $this->errors;
-    }
-
-    protected function setErrors(array $errors) : void
-    {
-        $this->errors = $errors;
-    }
-
     public function validateParameters() : void
     {
         // Override with custom validation of worker parameters
     }
 
-    public function getTrackerData() : array
+    protected function setErrors(array $errors) : void
     {
-        return [];
+        $this->errors = $errors;
     }
 }

--- a/src/Job/Workers/DynamoDBTrackerWorker.php
+++ b/src/Job/Workers/DynamoDBTrackerWorker.php
@@ -24,11 +24,11 @@ class DynamoDBTrackerWorker extends DefaultWorker implements TrackingWorkerInter
     /** @var array */
     protected $config;
 
-    /** @var LoggerInterface */
-    protected $logger;
-
     /** @var Job */
     protected $job;
+
+    /** @var LoggerInterface */
+    protected $logger;
 
     /** @var string */
     protected $table;
@@ -38,6 +38,25 @@ class DynamoDBTrackerWorker extends DefaultWorker implements TrackingWorkerInter
         $this->client = $client;
         $this->config = $config;
         $this->logger = $logger;
+    }
+
+    public function setParameters(array $parameters) : void
+    {
+        parent::setParameters($parameters);
+
+        $this->job = $parameters['job'] ?? null;
+        $this->table = $parameters['table'] ?? '';
+    }
+
+    public function validateParameters() : void
+    {
+        if (!isset($this->parameters['job']) || !is_a($this->parameters['job'], Job::class)) {
+            throw new InvalidWorkerParameterException($this, 'job');
+        }
+
+        if (empty($this->parameters['table'])) {
+            throw new InvalidWorkerParameterException($this, 'table');
+        }
     }
 
     public function work() : bool
@@ -60,24 +79,5 @@ class DynamoDBTrackerWorker extends DefaultWorker implements TrackingWorkerInter
 
         // Tracking should not have impact on the job itself
         return true;
-    }
-
-    public function setParameters(array $parameters) : void
-    {
-        parent::setParameters($parameters);
-
-        $this->job = $parameters['job'] ?? null;
-        $this->table = $parameters['table'] ?? '';
-    }
-
-    public function validateParameters() : void
-    {
-        if (!isset($this->parameters['job']) || !is_a($this->parameters['job'], Job::class)) {
-            throw new InvalidWorkerParameterException($this, 'job');
-        }
-
-        if (empty($this->parameters['table'])) {
-            throw new InvalidWorkerParameterException($this, 'table');
-        }
     }
 }

--- a/src/Job/Workers/Factory/DefaultWorkerFactory.php
+++ b/src/Job/Workers/Factory/DefaultWorkerFactory.php
@@ -23,10 +23,10 @@ abstract class DefaultWorkerFactory implements WorkerFactoryInterface
         $this->loadIdleConfig();
     }
 
+    abstract public function createWorker(string $workerIdentifier, array $parameters = []) : WorkerInterface;
+
     protected function loadIdleConfig() : void
     {
         $this->idleConfig = $this->container->get(IdleConfig::class);
     }
-
-    abstract public function createWorker(string $workerIdentifier, array $parameters = []) : WorkerInterface;
 }

--- a/src/Job/Workers/PublishSubscribe/AcknowledgeMessageWorker.php
+++ b/src/Job/Workers/PublishSubscribe/AcknowledgeMessageWorker.php
@@ -17,13 +17,6 @@ class AcknowledgeMessageWorker extends DefaultWorker
     /** @var SubscriptionMessageInterface */
     protected $message;
 
-    public function work() : bool
-    {
-        $this->message->acknowledge($this->getParameters());
-
-        return true;
-    }
-
     public function setParameters(array $parameters) : void
     {
         $this->message = $parameters['message'] ?? null;
@@ -38,5 +31,12 @@ class AcknowledgeMessageWorker extends DefaultWorker
         if (is_null($this->message) || !is_a($this->message, SubscriptionMessageInterface::class)) {
             throw new InvalidWorkerParameterException($this, 'message');
         }
+    }
+
+    public function work() : bool
+    {
+        $this->message->acknowledge($this->getParameters());
+
+        return true;
     }
 }

--- a/src/Job/Workers/Queue/DeleteMessageWorker.php
+++ b/src/Job/Workers/Queue/DeleteMessageWorker.php
@@ -17,13 +17,6 @@ class DeleteMessageWorker extends DefaultWorker
     /** @var QueueMessageInterface */
     protected $message;
 
-    public function work() : bool
-    {
-        $this->message->delete($this->getParameters());
-
-        return true;
-    }
-
     public function setParameters(array $parameters) : void
     {
         $this->message = $parameters['message'] ?? null;
@@ -38,5 +31,12 @@ class DeleteMessageWorker extends DefaultWorker
         if (is_null($this->message) || !is_a($this->message, QueueMessageInterface::class)) {
             throw new InvalidWorkerParameterException($this, 'message');
         }
+    }
+
+    public function work() : bool
+    {
+        $this->message->delete($this->getParameters());
+
+        return true;
     }
 }

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -9,14 +9,9 @@ use JsonSerializable;
 interface Message extends JsonSerializable
 {
     /**
-     * Retrieve the id for the given message.
+     * Get message attributes.
      */
-    public function getMessageId() : string;
-
-    /**
-     * Set the id for the message.
-     */
-    public function setMessageId(string $messageIdentifier) : void;
+    public function getAttributes() : array;
 
     /**
      * Retrieve the message body.
@@ -24,14 +19,29 @@ interface Message extends JsonSerializable
     public function getBody() : string;
 
     /**
-     * Set the message body.
+     * Retrieve the message type identifier.
      */
-    public function setBody(string $body) : void;
+    public function getIdleIdentifier() : string;
 
     /**
-     * Get message attributes.
+     * Retrieve the id for the given message.
      */
-    public function getAttributes() : array;
+    public function getMessageId() : string;
+
+    /**
+     * Retrieve the service for which the message belongs.
+     */
+    public function getService() : ?Service;
+
+    /**
+     * Retrieve name of the source where the message resides.  Examples: topic name, queue name, etc.
+     */
+    public function getSourceName() : string;
+
+    /**
+     * Retrieve any temporary metadata such as receipt id, retrieval time, etc.
+     */
+    public function getTemporaryMetadata() : array;
 
     /**
      * Set message attributes.
@@ -39,9 +49,19 @@ interface Message extends JsonSerializable
     public function setAttributes(array $attributes) : void;
 
     /**
-     * Retrieve any temporary metadata such as receipt id, retrieval time, etc.
+     * Set the message body.
      */
-    public function getTemporaryMetadata() : array;
+    public function setBody(string $body) : void;
+
+    /**
+     * Set the id for the message.
+     */
+    public function setMessageId(string $messageIdentifier) : void;
+
+    /**
+     * Set the service for which the message belongs.
+     */
+    public function setService(Service $service) : void;
 
     /**
      * Set the temporary metadata such as receipt id, retrieval time, etc.
@@ -57,24 +77,4 @@ interface Message extends JsonSerializable
      * Create a message instance from array data.
      */
     public static function fromArray(array $parameters) : Message;
-
-    /**
-     * Retrieve the message type identifier.
-     */
-    public function getIdleIdentifier() : string;
-
-    /**
-     * Retrieve name of the source where the message resides.  Examples: topic name, queue name, etc.
-     */
-    public function getSourceName() : string;
-
-    /**
-     * Set the service for which the message belongs.
-     */
-    public function setService(Service $service) : void;
-
-    /**
-     * Retrieve the service for which the message belongs.
-     */
-    public function getService() : ?Service;
 }

--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -17,20 +17,20 @@ interface MessageFactory
     public function createMessage(array $messageParameters) : Message;
 
     /**
-     * Create a SendableMessage from message data array.  Typically this is used to create a message
-     * containing all the data which we want to add to the queue or topic.
-     *
-     * @throws InvalidMessageParameterException
-     */
-    public function createSendableMessage(array $messageParameters) : SendableMessage;
-
-    /**
      * Create a ReceivableMessage from message data array.  Typically this is used to define the
      * queue_identifier, or subscription_identifier parameters.
      *
      * @throws InvalidMessageParameterException
      */
     public function createReceivableMessage(array $messageParameters) : ReceivableMessage;
+
+    /**
+     * Create a SendableMessage from message data array.  Typically this is used to create a message
+     * containing all the data which we want to add to the queue or topic.
+     *
+     * @throws InvalidMessageParameterException
+     */
+    public function createSendableMessage(array $messageParameters) : SendableMessage;
 
     /**
      * Create a ReceivableMessage and perform a receive on it which will cause it to retrieve a message from the queue.

--- a/src/Message/Messages/DefaultMessage.php
+++ b/src/Message/Messages/DefaultMessage.php
@@ -9,14 +9,13 @@ use LinioPay\Idle\Message\Service;
 
 abstract class DefaultMessage implements MessageInterface
 {
-    /** @var string */
-    protected $messageId;
+    /** @var array */
+    protected $attributes;
 
     /** @var string */
     protected $body;
-
-    /** @var array */
-    protected $attributes;
+    /** @var string */
+    protected $messageId;
 
     /** @var array */
     protected $metadata;
@@ -32,14 +31,9 @@ abstract class DefaultMessage implements MessageInterface
         $this->metadata = $metadata;
     }
 
-    public function getMessageId() : string
+    public function getAttributes() : array
     {
-        return $this->messageId;
-    }
-
-    public function setMessageId(string $messageId) : void
-    {
-        $this->messageId = $messageId;
+        return $this->attributes;
     }
 
     public function getBody() : string
@@ -47,29 +41,19 @@ abstract class DefaultMessage implements MessageInterface
         return $this->body;
     }
 
-    public function setBody(string $body) : void
+    public function getMessageId() : string
     {
-        $this->body = $body;
+        return $this->messageId;
     }
 
-    public function getAttributes() : array
+    public function getService() : ?Service
     {
-        return $this->attributes;
-    }
-
-    public function setAttributes(array $attributes) : void
-    {
-        $this->attributes = $attributes;
+        return $this->service;
     }
 
     public function getTemporaryMetadata() : array
     {
         return $this->metadata;
-    }
-
-    public function setTemporaryMetadata(array $metadata) : void
-    {
-        $this->metadata = $metadata;
     }
 
     public function jsonSerialize()
@@ -81,14 +65,29 @@ abstract class DefaultMessage implements MessageInterface
         return $data;
     }
 
-    public function getService() : ?Service
+    public function setAttributes(array $attributes) : void
     {
-        return $this->service;
+        $this->attributes = $attributes;
+    }
+
+    public function setBody(string $body) : void
+    {
+        $this->body = $body;
+    }
+
+    public function setMessageId(string $messageId) : void
+    {
+        $this->messageId = $messageId;
     }
 
     public function setService(Service $service) : void
     {
         $this->service = $service;
+    }
+
+    public function setTemporaryMetadata(array $metadata) : void
+    {
+        $this->metadata = $metadata;
     }
 
     abstract public function toArray() : array;

--- a/src/Message/Messages/Factory/DefaultServiceFactory.php
+++ b/src/Message/Messages/Factory/DefaultServiceFactory.php
@@ -24,10 +24,10 @@ abstract class DefaultServiceFactory implements ServiceFactoryInterface
         $this->loadIdleConfig();
     }
 
+    abstract public function createFromMessage(Message $message) : Service;
+
     protected function loadIdleConfig() : void
     {
         $this->idleConfig = $this->container->get(IdleConfig::class);
     }
-
-    abstract public function createFromMessage(Message $message) : Service;
 }

--- a/src/Message/Messages/Factory/MessageFactory.php
+++ b/src/Message/Messages/Factory/MessageFactory.php
@@ -36,11 +36,6 @@ class MessageFactory implements MessageFactoryInterface
         $this->loadIdleConfig();
     }
 
-    protected function loadIdleConfig() : void
-    {
-        $this->idleConfig = $this->container->get(IdleConfig::class);
-    }
-
     public function createMessage(array $messageParameters) : MessageInterface
     {
         /** @var MessageInterface $message */
@@ -50,27 +45,6 @@ class MessageFactory implements MessageFactoryInterface
         $serviceFactory = $this->container->get(ServiceFactoryInterface::class);
 
         $message->setService($serviceFactory->createFromMessage($message));
-
-        return $message;
-    }
-
-    public function receiveMessageOrFail(array $messageParameters, array $receiveParameters = []) : MessageInterface
-    {
-        return $this->createReceivableMessage($messageParameters)->receiveOneOrFail($receiveParameters);
-    }
-
-    public function receiveMessages(array $messageParameters, array $receiveParameters = []) : array
-    {
-        return $this->createReceivableMessage($messageParameters)->receive($receiveParameters);
-    }
-
-    public function createSendableMessage(array $messageParameters) : SendableMessageInterface
-    {
-        $message = $this->createMessage($messageParameters);
-
-        if (!is_a($message, SendableMessageInterface::class)) {
-            throw new InvalidMessageParameterException('topic_identifier|queue_identifier');
-        }
 
         return $message;
     }
@@ -86,6 +60,27 @@ class MessageFactory implements MessageFactoryInterface
         return $message;
     }
 
+    public function createSendableMessage(array $messageParameters) : SendableMessageInterface
+    {
+        $message = $this->createMessage($messageParameters);
+
+        if (!is_a($message, SendableMessageInterface::class)) {
+            throw new InvalidMessageParameterException('topic_identifier|queue_identifier');
+        }
+
+        return $message;
+    }
+
+    public function receiveMessageOrFail(array $messageParameters, array $receiveParameters = []) : MessageInterface
+    {
+        return $this->createReceivableMessage($messageParameters)->receiveOneOrFail($receiveParameters);
+    }
+
+    public function receiveMessages(array $messageParameters, array $receiveParameters = []) : array
+    {
+        return $this->createReceivableMessage($messageParameters)->receive($receiveParameters);
+    }
+
     protected function getMessageClassFromParameters(array $parameters) : string
     {
         $foundKeys = array_intersect_key(self::TYPE_IDENTIFIER_MAP, $parameters);
@@ -95,5 +90,10 @@ class MessageFactory implements MessageFactoryInterface
         }
 
         return self::TYPE_IDENTIFIER_MAP[current(array_keys($foundKeys))];
+    }
+
+    protected function loadIdleConfig() : void
+    {
+        $this->idleConfig = $this->container->get(IdleConfig::class);
     }
 }

--- a/src/Message/Messages/PublishSubscribe/Message/TopicMessage.php
+++ b/src/Message/Messages/PublishSubscribe/Message/TopicMessage.php
@@ -14,11 +14,10 @@ use LinioPay\Idle\Message\SendableMessage as SendableMessageInterface;
 
 class TopicMessage extends DefaultMessage implements TopicMessageInterface, SendableMessageInterface
 {
-    /** @var string */
-    protected $topicIdentifier;
-
     /** @var PublishSubscribeServiceInterface */
     protected $service;
+    /** @var string */
+    protected $topicIdentifier;
 
     public function __construct(string $topicIdentifier, string $body = '', array $attributes = [], string $messageIdentifier = '', array $metadata = [])
     {
@@ -26,9 +25,39 @@ class TopicMessage extends DefaultMessage implements TopicMessageInterface, Send
         parent::__construct($body, $attributes, $messageIdentifier, $metadata);
     }
 
+    public function getIdleIdentifier() : string
+    {
+        return TopicMessageInterface::IDENTIFIER;
+    }
+
+    public function getSourceName() : string
+    {
+        return $this->getTopicIdentifier();
+    }
+
     public function getTopicIdentifier() : string
     {
         return $this->topicIdentifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function publish(array $parameters = []) : bool
+    {
+        if (is_null($this->service)) {
+            throw new UndefinedServiceException($this);
+        }
+
+        return $this->service->publish($this, $parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(array $parameters = []) : bool
+    {
+        return $this->publish($parameters);
     }
 
     public function toArray() : array
@@ -59,35 +88,5 @@ class TopicMessage extends DefaultMessage implements TopicMessageInterface, Send
             $parameters['message_identifier'] ?? '',
             $parameters['metadata'] ?? []
         );
-    }
-
-    public function getIdleIdentifier() : string
-    {
-        return TopicMessageInterface::IDENTIFIER;
-    }
-
-    public function getSourceName() : string
-    {
-        return $this->getTopicIdentifier();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function publish(array $parameters = []) : bool
-    {
-        if (is_null($this->service)) {
-            throw new UndefinedServiceException($this);
-        }
-
-        return $this->service->publish($this, $parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function send(array $parameters = []) : bool
-    {
-        return $this->publish($parameters);
     }
 }

--- a/src/Message/Messages/PublishSubscribe/Service.php
+++ b/src/Message/Messages/PublishSubscribe/Service.php
@@ -9,6 +9,8 @@ use LinioPay\Idle\Message\Service as ServiceInterface;
 
 interface Service extends ServiceInterface
 {
+    public function acknowledge(SubscriptionMessage $message, array $parameters = []) : bool;
+
     public function publish(TopicMessage $message, array $parameters = []) : bool;
 
     /**
@@ -17,6 +19,4 @@ interface Service extends ServiceInterface
     public function pull(string $subscriptionIdentifier, array $parameters = []) : array;
 
     public function pullOneOrFail(string $subscriptionIdentifier, array $parameters = []) : MessageInterface;
-
-    public function acknowledge(SubscriptionMessage $message, array $parameters = []) : bool;
 }

--- a/src/Message/Messages/PublishSubscribe/Service/DefaultService.php
+++ b/src/Message/Messages/PublishSubscribe/Service/DefaultService.php
@@ -14,14 +14,24 @@ abstract class DefaultService implements Service
     /** @var array */
     protected $config;
 
+    public function getAcknowledgeErrorConfig() : array
+    {
+        return $this->config['acknowledge']['error'] ?? [];
+    }
+
+    public function getAcknowledgeParameterConfig() : array
+    {
+        return $this->config['acknowledge']['parameters'] ?? [];
+    }
+
     public function getConfig() : array
     {
         return $this->config;
     }
 
-    public function getServiceConfig() : array
+    public function getPublishErrorConfig() : array
     {
-        return $this->config['parameters']['service'] ?? [];
+        return $this->config['publish']['error'] ?? [];
     }
 
     public function getPublishParameterConfig() : array
@@ -29,9 +39,26 @@ abstract class DefaultService implements Service
         return $this->config['publish']['parameters'] ?? [];
     }
 
-    public function getPublishErrorConfig() : array
+    public function getPullErrorConfig() : array
     {
-        return $this->config['publish']['error'] ?? [];
+        return $this->config['pull']['error'] ?? [];
+    }
+
+    public function getPullParameterConfig() : array
+    {
+        return $this->config['pull']['parameters'] ?? [];
+    }
+
+    public function getServiceConfig() : array
+    {
+        return $this->config['parameters']['service'] ?? [];
+    }
+
+    protected function isAcknowledgeErrorSuppressed() : bool
+    {
+        $errorConfig = $this->getAcknowledgeErrorConfig();
+
+        return $errorConfig['suppression'] ?? false;
     }
 
     protected function isPublishErrorSuppressed() : bool
@@ -41,36 +68,9 @@ abstract class DefaultService implements Service
         return $errorConfig['suppression'] ?? false;
     }
 
-    public function getPullParameterConfig() : array
-    {
-        return $this->config['pull']['parameters'] ?? [];
-    }
-
-    public function getPullErrorConfig() : array
-    {
-        return $this->config['pull']['error'] ?? [];
-    }
-
     protected function isPullErrorSuppressed() : bool
     {
         $errorConfig = $this->getPullErrorConfig();
-
-        return $errorConfig['suppression'] ?? false;
-    }
-
-    public function getAcknowledgeParameterConfig() : array
-    {
-        return $this->config['acknowledge']['parameters'] ?? [];
-    }
-
-    public function getAcknowledgeErrorConfig() : array
-    {
-        return $this->config['acknowledge']['error'] ?? [];
-    }
-
-    protected function isAcknowledgeErrorSuppressed() : bool
-    {
-        $errorConfig = $this->getAcknowledgeErrorConfig();
 
         return $errorConfig['suppression'] ?? false;
     }

--- a/src/Message/Messages/PublishSubscribe/SubscriptionMessage.php
+++ b/src/Message/Messages/PublishSubscribe/SubscriptionMessage.php
@@ -10,12 +10,12 @@ interface SubscriptionMessage extends MessageInterface
 {
     const IDENTIFIER = 'subscription';
 
-    public function getSubscriptionIdentifier() : string;
-
     /**
      * Proxies call to acknowledge on the service.
      */
     public function acknowledge(array $parameters = []) : bool;
+
+    public function getSubscriptionIdentifier() : string;
 
     /**
      * Proxies call to pull an array of messages from the service.

--- a/src/Message/Messages/Queue/Message.php
+++ b/src/Message/Messages/Queue/Message.php
@@ -11,12 +11,10 @@ interface Message extends MessageInterface
 {
     const IDENTIFIER = 'queue';
 
-    public function getQueueIdentifier() : string;
-
     /**
-     * Proxies a queue call to the service to queue the message.
+     * Proxies a delete call to the service.
      */
-    public function queue(array $parameters = []) : bool;
+    public function delete(array $parameters = []) : bool;
 
     /**
      * Proxies a dequeue call to the service to retreive message(s).
@@ -32,8 +30,10 @@ interface Message extends MessageInterface
      */
     public function dequeueOneOrFail(array $parameters = []) : MessageInterface;
 
+    public function getQueueIdentifier() : string;
+
     /**
-     * Proxies a delete call to the service.
+     * Proxies a queue call to the service to queue the message.
      */
-    public function delete(array $parameters = []) : bool;
+    public function queue(array $parameters = []) : bool;
 }

--- a/src/Message/Messages/Queue/Message/Message.php
+++ b/src/Message/Messages/Queue/Message/Message.php
@@ -27,9 +27,91 @@ class Message extends DefaultMessage implements QueueMessageInterface, SendableM
         parent::__construct($body, $attributes, $messageIdentifier, $metadata);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(array $parameters = []) : bool
+    {
+        if (is_null($this->service)) {
+            throw new UndefinedServiceException($this);
+        }
+
+        return $this->service->delete($this, $parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dequeue(array $parameters = []) : array
+    {
+        if (is_null($this->service)) {
+            throw new UndefinedServiceException($this);
+        }
+
+        return $this->service->dequeue($this->getQueueIdentifier(), $parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dequeueOneOrFail(array $parameters = []) : MessageInterface
+    {
+        if (is_null($this->service)) {
+            throw new UndefinedServiceException($this);
+        }
+
+        return $this->service->dequeueOneOrFail($this->getQueueIdentifier(), $parameters);
+    }
+
+    public function getIdleIdentifier() : string
+    {
+        return QueueMessageInterface::IDENTIFIER;
+    }
+
     public function getQueueIdentifier() : string
     {
         return $this->queueIdentifier;
+    }
+
+    public function getSourceName() : string
+    {
+        return $this->getQueueIdentifier();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function queue(array $parameters = []) : bool
+    {
+        if (is_null($this->service)) {
+            throw new UndefinedServiceException($this);
+        }
+
+        return $this->service->queue($this, $parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function receive(array $parameters = []) : array
+    {
+        return $this->dequeue($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function receiveOneOrFail(array $parameters = []) : MessageInterface
+    {
+        return $this->dequeueOneOrFail($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(array $parameters = []) : bool
+    {
+        return $this->queue($parameters);
     }
 
     public function toArray() : array
@@ -60,87 +142,5 @@ class Message extends DefaultMessage implements QueueMessageInterface, SendableM
             $parameters['message_identifier'] ?? '',
             $parameters['metadata'] ?? []
         );
-    }
-
-    public function getIdleIdentifier() : string
-    {
-        return QueueMessageInterface::IDENTIFIER;
-    }
-
-    public function getSourceName() : string
-    {
-        return $this->getQueueIdentifier();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function queue(array $parameters = []) : bool
-    {
-        if (is_null($this->service)) {
-            throw new UndefinedServiceException($this);
-        }
-
-        return $this->service->queue($this, $parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function send(array $parameters = []) : bool
-    {
-        return $this->queue($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dequeue(array $parameters = []) : array
-    {
-        if (is_null($this->service)) {
-            throw new UndefinedServiceException($this);
-        }
-
-        return $this->service->dequeue($this->getQueueIdentifier(), $parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function receive(array $parameters = []) : array
-    {
-        return $this->dequeue($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dequeueOneOrFail(array $parameters = []) : MessageInterface
-    {
-        if (is_null($this->service)) {
-            throw new UndefinedServiceException($this);
-        }
-
-        return $this->service->dequeueOneOrFail($this->getQueueIdentifier(), $parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function receiveOneOrFail(array $parameters = []) : MessageInterface
-    {
-        return $this->dequeueOneOrFail($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function delete(array $parameters = []) : bool
-    {
-        if (is_null($this->service)) {
-            throw new UndefinedServiceException($this);
-        }
-
-        return $this->service->delete($this, $parameters);
     }
 }

--- a/src/Message/Messages/Queue/Service.php
+++ b/src/Message/Messages/Queue/Service.php
@@ -10,7 +10,7 @@ use LinioPay\Idle\Message\Service as ServiceInterface;
 
 interface Service extends ServiceInterface
 {
-    public function queue(Message $message, array $parameters = []) : bool;
+    public function delete(Message $message, array $parameters = []) : bool;
 
     /**
      * @return MessageInterface[]
@@ -22,5 +22,5 @@ interface Service extends ServiceInterface
      */
     public function dequeueOneOrFail(string $queueIdentifier, array $parameters = []) : MessageInterface;
 
-    public function delete(Message $message, array $parameters = []) : bool;
+    public function queue(Message $message, array $parameters = []) : bool;
 }

--- a/src/Message/Messages/Queue/Service/DefaultService.php
+++ b/src/Message/Messages/Queue/Service/DefaultService.php
@@ -24,21 +24,19 @@ abstract class DefaultService implements QueueServiceInterface
         return $this->config['parameters']['service'] ?? [];
     }
 
-    protected function getQueueingParameters() : array
+    protected function getDeletingErrorConfig() : array
     {
-        return $this->config['queue']['parameters'] ?? [];
+        return $this->config['delete']['error'] ?? [];
     }
 
-    protected function getQueueingErrorConfig() : array
+    protected function getDeletingParameters() : array
     {
-        return $this->config['queue']['error'] ?? [];
+        return $this->config['delete']['parameters'] ?? [];
     }
 
-    protected function isQueueingErrorSuppression() : bool
+    protected function getDequeueingErrorConfig() : array
     {
-        $errorConfig = $this->getQueueingErrorConfig();
-
-        return $errorConfig['suppression'] ?? false;
+        return $this->config['dequeue']['error'] ?? [];
     }
 
     protected function getDequeueingParameters() : array
@@ -46,9 +44,21 @@ abstract class DefaultService implements QueueServiceInterface
         return $this->config['dequeue']['parameters'] ?? [];
     }
 
-    protected function getDequeueingErrorConfig() : array
+    protected function getQueueingErrorConfig() : array
     {
-        return $this->config['dequeue']['error'] ?? [];
+        return $this->config['queue']['error'] ?? [];
+    }
+
+    protected function getQueueingParameters() : array
+    {
+        return $this->config['queue']['parameters'] ?? [];
+    }
+
+    protected function isDeletingErrorSuppression() : bool
+    {
+        $errorConfig = $this->getDeletingErrorConfig();
+
+        return $errorConfig['suppression'] ?? false;
     }
 
     protected function isDequeueingErrorSuppression() : bool
@@ -58,19 +68,9 @@ abstract class DefaultService implements QueueServiceInterface
         return $errorConfig['suppression'] ?? false;
     }
 
-    protected function getDeletingParameters() : array
+    protected function isQueueingErrorSuppression() : bool
     {
-        return $this->config['delete']['parameters'] ?? [];
-    }
-
-    protected function getDeletingErrorConfig() : array
-    {
-        return $this->config['delete']['error'] ?? [];
-    }
-
-    protected function isDeletingErrorSuppression() : bool
-    {
-        $errorConfig = $this->getDeletingErrorConfig();
+        $errorConfig = $this->getQueueingErrorConfig();
 
         return $errorConfig['suppression'] ?? false;
     }

--- a/tests/Config/IdleConfigTest.php
+++ b/tests/Config/IdleConfigTest.php
@@ -18,11 +18,11 @@ class IdleConfigTest extends TestCase
     /** @var IdleConfig */
     protected $config;
 
-    protected $services;
+    protected $jobs;
 
     protected $messages;
 
-    protected $jobs;
+    protected $services;
 
     protected $workers;
 
@@ -95,14 +95,6 @@ class IdleConfigTest extends TestCase
         );
     }
 
-    public function testCanGetMainConfigs()
-    {
-        $this->assertSame($this->services, $this->config->getServicesConfig());
-        $this->assertSame($this->messages, $this->config->getMessagesConfig());
-        $this->assertSame($this->jobs, $this->config->getJobsConfig());
-        $this->assertSame($this->workers, $this->config->getWorkersConfig());
-    }
-
     public function testCanGetConfigsByIdentifier()
     {
         $this->assertSame($this->services[SQS::IDENTIFIER], $this->config->getServiceConfig(SQS::IDENTIFIER));
@@ -117,6 +109,14 @@ class IdleConfigTest extends TestCase
         $this->assertSame($this->workers[FooWorker::IDENTIFIER]['class'], $this->config->getWorkerClass(FooWorker::IDENTIFIER));
     }
 
+    public function testCanGetMainConfigs()
+    {
+        $this->assertSame($this->services, $this->config->getServicesConfig());
+        $this->assertSame($this->messages, $this->config->getMessagesConfig());
+        $this->assertSame($this->jobs, $this->config->getJobsConfig());
+        $this->assertSame($this->workers, $this->config->getWorkersConfig());
+    }
+
     public function testCanGetMergedWorkerConfig()
     {
         $this->assertSame([
@@ -128,6 +128,12 @@ class IdleConfigTest extends TestCase
         ], $this->config->getMergedWorkerConfig(FooWorker::IDENTIFIER, [
             'foo' => 'bar',
         ]));
+    }
+
+    public function testWillThrowExceptionWhenJobTypeDoesNotExist()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->config->getJobConfig('fail_type');
     }
 
     public function testWillThrowExceptionWhenMessageTypeDoesNotExist()
@@ -146,11 +152,5 @@ class IdleConfigTest extends TestCase
 
         $this->expectException(ConfigurationException::class);
         $this->config->getMessageConfig($message);
-    }
-
-    public function testWillThrowExceptionWhenJobTypeDoesNotExist()
-    {
-        $this->expectException(ConfigurationException::class);
-        $this->config->getJobConfig('fail_type');
     }
 }

--- a/tests/Job/Jobs/MessageJobTest.php
+++ b/tests/Job/Jobs/MessageJobTest.php
@@ -22,14 +22,13 @@ use Mockery\Mock;
 
 class MessageJobTest extends TestCase
 {
-    /** @var Mock|WorkerFactory */
-    protected $workerFactory;
+    /** @var IdleConfig */
+    protected $idleConfig;
 
     /** @var Mock|MessageFactoryInterface */
     protected $messageFactory;
-
-    /** @var IdleConfig */
-    protected $idleConfig;
+    /** @var Mock|WorkerFactory */
+    protected $workerFactory;
 
     public function setUp() : void
     {

--- a/tests/Job/Workers/DynamoDBTrackerWorkerTest.php
+++ b/tests/Job/Workers/DynamoDBTrackerWorkerTest.php
@@ -14,6 +14,49 @@ use Psr\Log\LoggerInterface;
 
 class DynamoDBTrackerWorkerTest extends TestCase
 {
+    public function testItLogsDetailsAfterThrowable()
+    {
+        $trackerData = [
+            'id' => 'foo_id',
+            'success' => true,
+        ];
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('getTrackerData')
+            ->twice()
+            ->andReturn($trackerData);
+
+        $client = m::mock(DynamoDbClient::class)->shouldAllowMockingMethod('putItem');
+        $client->shouldReceive('putItem')
+            ->once()
+            ->andThrow(new Exception('kaboom!'));
+
+        $config = [];
+
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('debug')
+            ->once()
+            ->with('Idle tracking a job.', $trackerData);
+        $logger->shouldReceive('error')
+            ->once()
+            ->with('Idle tracking encountered an error.', m::on(function ($context) {
+                $this->assertArrayHasKey('message', $context);
+                $this->assertArrayHasKey('code', $context);
+                $this->assertArrayHasKey('file', $context);
+                $this->assertArrayHasKey('line', $context);
+
+                return true;
+            }));
+
+        $worker = new DynamoDBTrackerWorker($client, $config, $logger);
+        $worker->setParameters([
+            'job' => $job,
+            'table' => 'foo_table',
+        ]);
+
+        $worker->work();
+    }
+
     public function testItTracksJobData()
     {
         $trackerData = [
@@ -89,48 +132,5 @@ class DynamoDBTrackerWorkerTest extends TestCase
 
         $this->expectException(InvalidWorkerParameterException::class);
         $worker->validateParameters();
-    }
-
-    public function testItLogsDetailsAfterThrowable()
-    {
-        $trackerData = [
-            'id' => 'foo_id',
-            'success' => true,
-        ];
-
-        $job = m::mock(Job::class);
-        $job->shouldReceive('getTrackerData')
-            ->twice()
-            ->andReturn($trackerData);
-
-        $client = m::mock(DynamoDbClient::class)->shouldAllowMockingMethod('putItem');
-        $client->shouldReceive('putItem')
-            ->once()
-            ->andThrow(new Exception('kaboom!'));
-
-        $config = [];
-
-        $logger = m::mock(LoggerInterface::class);
-        $logger->shouldReceive('debug')
-            ->once()
-            ->with('Idle tracking a job.', $trackerData);
-        $logger->shouldReceive('error')
-            ->once()
-            ->with('Idle tracking encountered an error.', m::on(function ($context) {
-                $this->assertArrayHasKey('message', $context);
-                $this->assertArrayHasKey('code', $context);
-                $this->assertArrayHasKey('file', $context);
-                $this->assertArrayHasKey('line', $context);
-
-                return true;
-            }));
-
-        $worker = new DynamoDBTrackerWorker($client, $config, $logger);
-        $worker->setParameters([
-            'job' => $job,
-            'table' => 'foo_table',
-        ]);
-
-        $worker->work();
     }
 }

--- a/tests/Job/Workers/Factory/WorkerFactoryTest.php
+++ b/tests/Job/Workers/Factory/WorkerFactoryTest.php
@@ -14,6 +14,33 @@ use Psr\Container\ContainerInterface;
 
 class WorkerFactoryTest extends TestCase
 {
+    public function testCreateWorkerDoesNotForwardCallToAppropriateFactoryWhenSkipFactory()
+    {
+        $container = m::mock(ContainerInterface::class);
+        $container->shouldReceive('get')
+            ->with(IdleConfig::class)
+            ->andReturn(new IdleConfig([], [], [], [
+                FooWorker::IDENTIFIER => [
+                    'class' => FooWorker::class,
+                    'parameters' => [
+                        'red' => true,
+                    ],
+                ],
+            ]));
+
+        $factory = new WorkerFactory($container);
+
+        $this->assertInstanceOf(WorkerFactory::class, $factory);
+
+        $worker = $factory->createWorker(FooWorker::IDENTIFIER, ['blue' => true]);
+        $this->assertInstanceOf(FooWorker::class, $worker);
+
+        $parameters = $worker->getParameters();
+
+        $this->assertArrayHasKey('red', $parameters);
+        $this->assertArrayHasKey('blue', $parameters);
+    }
+
     public function testCreateWorkerForwardsCallToAppropriateFactory()
     {
         $container = m::mock(ContainerInterface::class);
@@ -37,33 +64,6 @@ class WorkerFactoryTest extends TestCase
 
         $worker = $factory->createWorker(BazWorker::IDENTIFIER, ['blue' => true]);
         $this->assertInstanceOf(BazWorker::class, $worker);
-
-        $parameters = $worker->getParameters();
-
-        $this->assertArrayHasKey('red', $parameters);
-        $this->assertArrayHasKey('blue', $parameters);
-    }
-
-    public function testCreateWorkerDoesNotForwardCallToAppropriateFactoryWhenSkipFactory()
-    {
-        $container = m::mock(ContainerInterface::class);
-        $container->shouldReceive('get')
-            ->with(IdleConfig::class)
-            ->andReturn(new IdleConfig([], [], [], [
-                FooWorker::IDENTIFIER => [
-                    'class' => FooWorker::class,
-                    'parameters' => [
-                        'red' => true,
-                    ],
-                ],
-            ]));
-
-        $factory = new WorkerFactory($container);
-
-        $this->assertInstanceOf(WorkerFactory::class, $factory);
-
-        $worker = $factory->createWorker(FooWorker::IDENTIFIER, ['blue' => true]);
-        $this->assertInstanceOf(FooWorker::class, $worker);
 
         $parameters = $worker->getParameters();
 

--- a/tests/Job/Workers/PublishSubscribe/AcknowledgeMessageWorkerTest.php
+++ b/tests/Job/Workers/PublishSubscribe/AcknowledgeMessageWorkerTest.php
@@ -13,6 +13,17 @@ use Mockery as m;
 
 class AcknowledgeMessageWorkerTest extends TestCase
 {
+    public function testItFailsValidation()
+    {
+        $message = m::mock(QueueMessageInterface::class);
+
+        $worker = new AcknowledgeMessageWorker();
+        $worker->setParameters(['job' => m::mock(Job::class), 'message' => $message, 'foo' => 'bar']);
+
+        $this->expectException(InvalidWorkerParameterException::class);
+        $worker->validateParameters();
+    }
+
     public function testItWorks()
     {
         $message = m::mock(SubscriptionMessageInterface::class);
@@ -25,16 +36,5 @@ class AcknowledgeMessageWorkerTest extends TestCase
         $worker->validateParameters();
 
         $this->assertTrue($worker->work());
-    }
-
-    public function testItFailsValidation()
-    {
-        $message = m::mock(QueueMessageInterface::class);
-
-        $worker = new AcknowledgeMessageWorker();
-        $worker->setParameters(['job' => m::mock(Job::class), 'message' => $message, 'foo' => 'bar']);
-
-        $this->expectException(InvalidWorkerParameterException::class);
-        $worker->validateParameters();
     }
 }

--- a/tests/Job/Workers/Queue/DeleteMessageWorkerTest.php
+++ b/tests/Job/Workers/Queue/DeleteMessageWorkerTest.php
@@ -13,6 +13,17 @@ use Mockery as m;
 
 class DeleteMessageWorkerTest extends TestCase
 {
+    public function testItFailsValidation()
+    {
+        $message = m::mock(SubscriptionMessageInterface::class);
+
+        $worker = new DeleteMessageWorker();
+        $worker->setParameters(['job' => m::mock(Job::class), 'message' => $message, 'foo' => 'bar']);
+
+        $this->expectException(InvalidWorkerParameterException::class);
+        $worker->validateParameters();
+    }
+
     public function testItWorks()
     {
         $message = m::mock(QueueMessageInterface::class);
@@ -25,16 +36,5 @@ class DeleteMessageWorkerTest extends TestCase
         $worker->validateParameters();
 
         $this->assertTrue($worker->work());
-    }
-
-    public function testItFailsValidation()
-    {
-        $message = m::mock(SubscriptionMessageInterface::class);
-
-        $worker = new DeleteMessageWorker();
-        $worker->setParameters(['job' => m::mock(Job::class), 'message' => $message, 'foo' => 'bar']);
-
-        $this->expectException(InvalidWorkerParameterException::class);
-        $worker->validateParameters();
     }
 }

--- a/tests/Message/Messages/PublishSubscribe/Message/SubscriptionMessageTest.php
+++ b/tests/Message/Messages/PublishSubscribe/Message/SubscriptionMessageTest.php
@@ -13,6 +13,25 @@ use Mockery as m;
 
 class SubscriptionMessageTest extends TestCase
 {
+    public function testAcknowledgeThrowsUndefinedServiceException()
+    {
+        $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
+
+        $this->expectException(UndefinedServiceException::class);
+        $message->acknowledge();
+    }
+
+    public function testFromArrayThrowsInvalidMessageParameterExceptionWhenMissingRequiredParameters()
+    {
+        $this->expectException(InvalidMessageParameterException::class);
+        SubscriptionMessage::fromArray([
+           'body' => 'foobody',
+           'attributes' => [
+               'red' => true,
+           ],
+        ]);
+    }
+
     public function testGettersAndSetters()
     {
         $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['meta' => true]);
@@ -43,34 +62,6 @@ class SubscriptionMessageTest extends TestCase
         $this->assertSame(SubscriptionMessage::IDENTIFIER, $message->getIdleIdentifier());
     }
 
-    public function testToArrayAndFromArray()
-    {
-        $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
-
-        $asArray = $jsonOut = $message->toArray();
-        $this->assertSame($asArray, SubscriptionMessage::fromArray($message->toArray())->toArray());
-
-        $this->assertArrayHasKey('message_identifier', $asArray);
-        $this->assertArrayHasKey('subscription_identifier', $asArray);
-        $this->assertArrayHasKey('body', $asArray);
-        $this->assertArrayHasKey('attributes', $asArray);
-        $this->assertArrayHasKey('metadata', $asArray);
-
-        unset($jsonOut['metadata']);
-        $this->assertSame($jsonOut, json_decode(json_encode($message), true));
-    }
-
-    public function testFromArrayThrowsInvalidMessageParameterExceptionWhenMissingRequiredParameters()
-    {
-        $this->expectException(InvalidMessageParameterException::class);
-        SubscriptionMessage::fromArray([
-           'body' => 'foobody',
-           'attributes' => [
-               'red' => true,
-           ],
-        ]);
-    }
-
     public function testProxiesCallToAcknowledge()
     {
         $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
@@ -85,14 +76,6 @@ class SubscriptionMessageTest extends TestCase
         $this->assertTrue($message->acknowledge(['foo' => 'bar']));
     }
 
-    public function testAcknowledgeThrowsUndefinedServiceException()
-    {
-        $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
-
-        $this->expectException(UndefinedServiceException::class);
-        $message->acknowledge();
-    }
-
     public function testProxiesCallToPull()
     {
         $message = new SubscriptionMessage('foo_subscription');
@@ -105,14 +88,6 @@ class SubscriptionMessageTest extends TestCase
 
         $message->setService($service);
         $this->assertSame(['foo'], $message->receive(['foo' => 'bar']));
-    }
-
-    public function testPullThrowsUndefinedServiceException()
-    {
-        $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
-
-        $this->expectException(UndefinedServiceException::class);
-        $message->pull();
     }
 
     public function testProxiesCallToPullOneOrFail()
@@ -137,5 +112,30 @@ class SubscriptionMessageTest extends TestCase
 
         $this->expectException(UndefinedServiceException::class);
         $message->pullOneOrFail();
+    }
+
+    public function testPullThrowsUndefinedServiceException()
+    {
+        $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
+
+        $this->expectException(UndefinedServiceException::class);
+        $message->pull();
+    }
+
+    public function testToArrayAndFromArray()
+    {
+        $message = new SubscriptionMessage('foo_subscription', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
+
+        $asArray = $jsonOut = $message->toArray();
+        $this->assertSame($asArray, SubscriptionMessage::fromArray($message->toArray())->toArray());
+
+        $this->assertArrayHasKey('message_identifier', $asArray);
+        $this->assertArrayHasKey('subscription_identifier', $asArray);
+        $this->assertArrayHasKey('body', $asArray);
+        $this->assertArrayHasKey('attributes', $asArray);
+        $this->assertArrayHasKey('metadata', $asArray);
+
+        unset($jsonOut['metadata']);
+        $this->assertSame($jsonOut, json_decode(json_encode($message), true));
     }
 }

--- a/tests/Message/Messages/PublishSubscribe/Message/TopicMessageTest.php
+++ b/tests/Message/Messages/PublishSubscribe/Message/TopicMessageTest.php
@@ -12,6 +12,17 @@ use Mockery as m;
 
 class TopicMessageTest extends TestCase
 {
+    public function testFromArrayThrowsInvalidMessageParameterExceptionWhenMissingRequiredParameters()
+    {
+        $this->expectException(InvalidMessageParameterException::class);
+        TopicMessage::fromArray([
+           'body' => 'foobody',
+           'attributes' => [
+               'red' => true,
+           ],
+        ]);
+    }
+
     public function testGettersAndSetters()
     {
         $message = new TopicMessage('foo_topic', 'body', ['red' => true], 'foo123', ['meta' => true]);
@@ -42,34 +53,6 @@ class TopicMessageTest extends TestCase
         $this->assertSame(TopicMessage::IDENTIFIER, $message->getIdleIdentifier());
     }
 
-    public function testToArrayAndFromArray()
-    {
-        $message = new TopicMessage('foo_topic', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
-
-        $asArray = $jsonOut = $message->toArray();
-        $this->assertSame($asArray, TopicMessage::fromArray($message->toArray())->toArray());
-
-        $this->assertArrayHasKey('message_identifier', $asArray);
-        $this->assertArrayHasKey('topic_identifier', $asArray);
-        $this->assertArrayHasKey('body', $asArray);
-        $this->assertArrayHasKey('attributes', $asArray);
-        $this->assertArrayHasKey('metadata', $asArray);
-
-        unset($jsonOut['metadata']);
-        $this->assertSame($jsonOut, json_decode(json_encode($message), true));
-    }
-
-    public function testFromArrayThrowsInvalidMessageParameterExceptionWhenMissingRequiredParameters()
-    {
-        $this->expectException(InvalidMessageParameterException::class);
-        TopicMessage::fromArray([
-           'body' => 'foobody',
-           'attributes' => [
-               'red' => true,
-           ],
-        ]);
-    }
-
     public function testProxiesCallToPublish()
     {
         $message = new TopicMessage('foo_topic', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
@@ -90,5 +73,22 @@ class TopicMessageTest extends TestCase
 
         $this->expectException(UndefinedServiceException::class);
         $message->publish();
+    }
+
+    public function testToArrayAndFromArray()
+    {
+        $message = new TopicMessage('foo_topic', 'body', ['red' => true], 'foo123', ['redmeta' => true]);
+
+        $asArray = $jsonOut = $message->toArray();
+        $this->assertSame($asArray, TopicMessage::fromArray($message->toArray())->toArray());
+
+        $this->assertArrayHasKey('message_identifier', $asArray);
+        $this->assertArrayHasKey('topic_identifier', $asArray);
+        $this->assertArrayHasKey('body', $asArray);
+        $this->assertArrayHasKey('attributes', $asArray);
+        $this->assertArrayHasKey('metadata', $asArray);
+
+        unset($jsonOut['metadata']);
+        $this->assertSame($jsonOut, json_decode(json_encode($message), true));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,19 +33,6 @@ class TestCase extends TestCaseBase
     }
 
     /**
-     * Injects a value into an inaccessible object property via reflection.
-     *
-     * @param mixed $classOrObject
-     * @param mixed $propertyValue
-     */
-    protected function inject($classOrObject, string $propertyNane, $propertyValue)
-    {
-        $property = new \ReflectionProperty($classOrObject, $propertyNane);
-        $property->setAccessible(true);
-        $property->setValue($classOrObject, $propertyValue);
-    }
-
-    /**
      * Creates a fake $className and injects any provided properties. This is a
      * quick way to create an instance of a class that requires constructor
      * arguments when they may not be relevant to what you are testing.
@@ -93,9 +80,22 @@ class TestCase extends TestCaseBase
     }
 
     /**
+     * Injects a value into an inaccessible object property via reflection.
+     *
+     * @param mixed $classOrObject
+     * @param mixed $propertyValue
+     */
+    protected function inject($classOrObject, string $propertyNane, $propertyValue)
+    {
+        $property = new \ReflectionProperty($classOrObject, $propertyNane);
+        $property->setAccessible(true);
+        $property->setValue($classOrObject, $propertyValue);
+    }
+
+    /**
      * Allows obtaining a method from the given class.
      *
-     * @param string $className  Name of the class being tested
+     * @param string $className Name of the class being tested
      * @param string $methodName Name of the method being tested
      *
      * @return ReflectionMethod


### PR DESCRIPTION
https://jira.falabella.tech/browse/CP-1084

Don't be scared by the amount of change, we're just trying to organize our code a little better.
We prioritize reading, which is why we will see the public classes first, then the protected ones and finally the private ones.
We also order the variables alphabetically.

The trick is here:
- use_trait
- constant_public
- constant_protected
- constant_private
- property_public
- property_protected
- property_private
- construct
- destruct
- magic
- phpunit
- method_public
- method_public_abstract
- method_protected_abstract
- method_protected
- method_private
- method_public_abstract_static
- method_protected_abstract_static
- method_public_static
- method_protected_static

Do you have any suggestions before merge?

What do we mean by PHPUnit?
- setUpBeforeClass
- doSetUpBeforeClass
- tearDownAfterClass
- doTearDownAfterClass
- setUp
- doSetUp
- assertPreConditions
- assertPostConditions
- tearDown
- doTearDown