### PR TITLE
fix: add missing return type

### DIFF
--- a/src/Message/Messages/DefaultMessage.php
+++ b/src/Message/Messages/DefaultMessage.php
@@ -56,7 +56,7 @@ abstract class DefaultMessage implements MessageInterface
         return $this->metadata;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         $data = $this->toArray();
 


### PR DESCRIPTION
- Added `array` return type to `jsonSerialize()` function on DefaultMessage.php